### PR TITLE
feat: proxy backpressure and connection limits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 # console-subscriber = "0.4"
 veil = "0.1"
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "sync", "net", "io-util", "time", "macros"] }
 rcgen = "0.13"
 rustls = { version = "0.23", features = ["ring"] }
 rustls-pemfile = "2"
@@ -65,6 +65,6 @@ mimalloc = { version = "*" }
 
 
 [features]
-default = ["s2n_quic"]
+default = []
 # s2n_quic = ["dep:s2n-quic", "dep:aws-lc-rs"]
 s2n_quic = ["dep:s2n-quic"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::Sender;
 use tokio::time;
 
 use url::Url;
@@ -45,6 +45,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 #[serde(rename_all = "lowercase")]
 enum Protocol {
     Tls,
+    #[cfg(feature = "s2n_quic")]
     Quic,
 }
 
@@ -140,6 +141,10 @@ struct Args {
     #[default(String::new())]
     #[arg(long)]
     log: String,
+
+    #[default(256)]
+    #[arg(long)]
+    max_connections: usize,
 
     /// HTTP server listen address (serves /metrics)
     #[default("127.0.0.1:48102".parse::<SocketAddr>().unwrap())]
@@ -330,8 +335,9 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
                 return Ok(());
             }
 
-            let tunnel_sender: UnboundedSender<tunnel::Message> =
+            let tunnel_sender: Sender<tunnel::Message> =
                 match args.remote.as_ref().unwrap().scheme() {
+                    #[cfg(feature = "s2n_quic")]
                     "quic" => {
                         tunnel::new_quic_client(
                             args.remote.as_ref().unwrap(),
@@ -364,7 +370,7 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
                 let mut interval = time::interval(Duration::from_secs(1));
                 loop {
                     interval.tick().await;
-                    if let Err(e) = health_checker.send(tunnel::Message::HealthCheck) {
+                    if let Err(e) = health_checker.send(tunnel::Message::HealthCheck).await {
                         tracing::error!("health check error:{}", e);
                     }
                 }
@@ -373,8 +379,9 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
             // Start local tunnel server in background
             let listen_addr = args.listen;
             let tproxy = args.tproxy;
+            let max_connections = args.max_connections;
             tokio::spawn(async move {
-                if let Err(e) = tunnel::start_local_tunnel_server(&listen_addr, tunnel_sender, tproxy).await {
+                if let Err(e) = tunnel::start_local_tunnel_server(&listen_addr, tunnel_sender, tproxy, max_connections).await {
                     tracing::error!("local tunnel server error: {e:?}");
                 }
             });
@@ -397,6 +404,7 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
             };
 
             match args.protocol {
+                #[cfg(feature = "s2n_quic")]
                 Protocol::Quic => {
                     if let Err(e) = tunnel::start_quic_remote_server(
                         &args.listen,

--- a/src/mux/connection.rs
+++ b/src/mux/connection.rs
@@ -13,6 +13,7 @@ use super::event;
 use super::stream::Control;
 
 pub const DEFAULT_STREAM_CHANNEL_SIZE: usize = 16;
+pub const CONTROL_CHANNEL_CAPACITY: usize = 256;
 
 pub struct Connection {
     ev_writer: mpsc::Sender<Control>,
@@ -36,7 +37,7 @@ impl Connection {
         id: u32,
         stream_channel_size: usize,
     ) -> Self {
-        let (sender_orig, receiver) = mpsc::channel::<Control>(4096);
+        let (sender_orig, receiver) = mpsc::channel::<Control>(CONTROL_CHANNEL_CAPACITY);
         let sender = sender_orig.clone();
         tokio::spawn(async move {
             handle_mux_connection(id, r, w, receiver, sender, stream_channel_size).await;

--- a/src/mux/event.rs
+++ b/src/mux/event.rs
@@ -21,7 +21,7 @@ pub const FLAG_AUTH_ACK: u8 = 9;
 pub const FLAG_REVERSE_OPEN: u8 = 10;
 
 pub const EVENT_HEADER_LEN: usize = 8;
-pub const MAX_EVENT_BODY_LEN: u32 = 16 * 1024 * 1024; // 16MB
+pub const MAX_EVENT_BODY_LEN: u32 = 256 * 1024; // 256KB (was 16MB, reduced for embedded)
 
 // pub fn get_event_type_str(flags: u8) -> &'static str {
 //     match flags {

--- a/src/tunnel/client.rs
+++ b/src/tunnel/client.rs
@@ -8,6 +8,15 @@ use url::Url;
 
 use crate::mux::event;
 use crate::mux::event::OpenStreamEvent;
+
+/// Bounded channel capacity for the proxy message queue.
+/// Limits memory growth under load via backpressure.
+pub const PROXY_CHANNEL_CAPACITY: usize = 256;
+
+/// Type alias for the bounded proxy message sender.
+pub type ProxySender = mpsc::Sender<Message>;
+/// Type alias for the bounded proxy message receiver.
+pub type ProxyReceiver = mpsc::Receiver<Message>;
 use crate::tunnel::stream::Stream;
 use crate::utils::UdpServerStream;
 
@@ -118,6 +127,7 @@ impl<T: MuxConnection> MuxClientTrait for MuxClient<T> {
         }
         Err(anyhow!("no available stream"))
     }
+
     async fn health_check(&mut self) -> anyhow::Result<()> {
         for c in &mut self.conns {
             if !c.is_valid() {
@@ -148,7 +158,7 @@ impl<T: MuxConnection> MuxClientTrait for MuxClient<T> {
 
 pub(crate) async fn mux_client_loop<T: MuxClientTrait>(
     mut client: T,
-    mut receiver: mpsc::UnboundedReceiver<Message>,
+    mut receiver: ProxyReceiver,
     idle_timeout_secs: usize,
 ) where
     <T as MuxClientTrait>::SendStream: 'static,

--- a/src/tunnel/http_local.rs
+++ b/src/tunnel/http_local.rs
@@ -1,10 +1,10 @@
+use crate::tunnel::client::ProxySender;
 use crate::tunnel::Message;
 use anyhow::{anyhow, Result};
 
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio::sync::mpsc;
 use tokio::time::timeout;
 
 use crate::tunnel::tls_local;
@@ -72,21 +72,21 @@ fn extract_target(headers_buf: &Vec<u8>, default_port: &str) -> Result<String> {
 pub async fn handle_http(
     _tunnel_id: u32,
     mut inbound: TcpStream,
-    sender: mpsc::UnboundedSender<Message>,
+    sender: ProxySender,
 ) -> Result<()> {
     let headers_buf = read_http_headers(&mut inbound).await?;
     let target_addr = extract_target(&headers_buf, ":80")?;
 
     tracing::info!("{}", target_addr);
     let msg = Message::open_tcp_stream(inbound, target_addr, Some(headers_buf));
-    sender.send(msg)?;
+    sender.send(msg).await?;
     Ok(())
 }
 
 pub async fn handle_https(
     tunnel_id: u32,
     mut inbound: TcpStream,
-    sender: mpsc::UnboundedSender<Message>,
+    sender: ProxySender,
 ) -> Result<()> {
     let headers_buf = read_http_headers(&mut inbound).await?;
     let conn_res = "HTTP/1.0 200 Connection established\r\n\r\n";
@@ -100,6 +100,6 @@ pub async fn handle_https(
     };
     tracing::info!("[{}]Handle HTTPS proxy to {} ", tunnel_id, target_addr);
     let msg = Message::open_tcp_stream(inbound, target_addr, None);
-    sender.send(msg)?;
+    sender.send(msg).await?;
     Ok(())
 }

--- a/src/tunnel/local.rs
+++ b/src/tunnel/local.rs
@@ -1,18 +1,19 @@
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use crate::tunnel::http_local::{handle_http, handle_https};
 use crate::tunnel::socks5_local::handle_socks5;
 use crate::tunnel::tls_local::{handle_tls, valid_tls_version};
-use crate::tunnel::Message;
+use crate::tunnel::client::ProxySender;
 use crate::utils::new_tcp_listener;
 use anyhow::{anyhow, Result};
 use tokio::net::TcpStream;
-use tokio::sync::mpsc;
+use tokio::sync::Semaphore;
 
 async fn handle_local_tunnel(
     inbound: TcpStream,
     tunnel_id: u32,
-    sender: mpsc::UnboundedSender<Message>,
+    sender: ProxySender,
 ) -> Result<()> {
     //stream.peek(buf)
     let mut peek_buf = [0u8; 3];
@@ -69,10 +70,12 @@ async fn handle_local_tunnel(
 
 pub async fn start_local_tunnel_server(
     addr: &SocketAddr,
-    sender: mpsc::UnboundedSender<Message>,
+    sender: ProxySender,
     tproxy: bool,
+    max_connections: usize,
 ) -> Result<(), std::io::Error> {
     let listener = new_tcp_listener(addr, tproxy).await?;
+    let semaphore = Arc::new(Semaphore::new(max_connections));
 
     #[cfg(target_os = "linux")]
     {
@@ -82,13 +85,21 @@ pub async fn start_local_tunnel_server(
         }
     }
 
-    tracing::info!("Start local TCP listen at {}", addr);
+    tracing::info!("Start local TCP listen at {} (max connections: {})", addr, max_connections);
     let mut tunnel_id_seed: u32 = 0;
     while let Ok((inbound, _)) = listener.accept().await {
+        let permit = match semaphore.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                tracing::warn!("Max connections ({}) reached, rejecting new connection", max_connections);
+                continue;
+            }
+        };
         let tunnel_id = tunnel_id_seed;
         tunnel_id_seed += 1;
         let tunnel_sender = sender.clone();
         tokio::spawn(async move {
+            let _permit = permit; // hold permit until task completes
             if let Err(e) = handle_local_tunnel(inbound, tunnel_id, tunnel_sender).await {
                 tracing::error!("handle local tunnel error:{}", e);
             }

--- a/src/tunnel/s2n_quic_client.rs
+++ b/src/tunnel/s2n_quic_client.rs
@@ -11,6 +11,7 @@ use url::Url;
 use super::client::mux_client_loop;
 use super::client::MuxClient;
 use super::client::MuxConnection;
+use super::client::{ProxySender, PROXY_CHANNEL_CAPACITY};
 use super::Message;
 use crate::mux::event::{
     self, AuthAck, AuthRequest, RegisterRequest, TunnelEntry, FLAG_AUTH_ACK,
@@ -88,10 +89,10 @@ impl MuxClient<S2NQuicConnection> {
         host: &String,
         count: usize,
         idle_timeout_secs: usize,
-    ) -> anyhow::Result<mpsc::UnboundedSender<Message>> {
+    ) -> anyhow::Result<ProxySender> {
         match url.scheme() {
             "quic" => {
-                let (sender, receiver) = mpsc::unbounded_channel::<Message>();
+                let (sender, receiver) = mpsc::channel::<Message>(PROXY_CHANNEL_CAPACITY);
                 let mut client: MuxClient<S2NQuicConnection> = MuxClient {
                     url: url.clone(),
                     conns: Vec::new(),
@@ -285,6 +286,6 @@ pub async fn new_quic_client(
     host: &String,
     count: usize,
     idle_timeout_secs: usize,
-) -> anyhow::Result<mpsc::UnboundedSender<Message>> {
+) -> anyhow::Result<ProxySender> {
     MuxClient::<S2NQuicConnection>::from(url, cert_path, host, count, idle_timeout_secs).await
 }

--- a/src/tunnel/socks5_local.rs
+++ b/src/tunnel/socks5_local.rs
@@ -3,8 +3,8 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
-use tokio::sync::mpsc;
 
+use crate::tunnel::client::ProxySender;
 use crate::tunnel::Message;
 
 mod v5 {
@@ -48,7 +48,7 @@ fn name_port(addr_buf: &[u8]) -> Option<String> {
 pub async fn handle_socks5(
     tunnel_id: u32,
     mut inbound: TcpStream,
-    sender: mpsc::UnboundedSender<Message>,
+    sender: ProxySender,
 ) -> Result<()> {
     //let mut peek_buf = Vec::new();
     let mut num_methods_buf = [0u8; 2];
@@ -125,6 +125,6 @@ pub async fn handle_socks5(
     tracing::info!("[{}]Handle SOCKS5 proxy to {}", tunnel_id, target_addr);
 
     let msg = Message::open_tcp_stream(inbound, target_addr, None);
-    sender.send(msg)?;
+    sender.send(msg).await?;
     Ok(())
 }

--- a/src/tunnel/tls_client.rs
+++ b/src/tunnel/tls_client.rs
@@ -13,6 +13,7 @@ use url::Url;
 use super::client::mux_client_loop;
 use super::client::MuxClient;
 use super::client::MuxConnection;
+use super::client::{ProxySender, PROXY_CHANNEL_CAPACITY};
 use super::Message;
 use crate::mux::event;
 use crate::mux::MuxStream;
@@ -112,10 +113,10 @@ impl MuxClient<TlsConnection> {
         count: usize,
         idle_timeout_secs: usize,
         stream_channel_size: usize,
-    ) -> anyhow::Result<mpsc::UnboundedSender<Message>> {
+    ) -> anyhow::Result<ProxySender> {
         match url.scheme() {
             "tls" => {
-                let (sender, receiver) = mpsc::unbounded_channel::<Message>();
+                let (sender, receiver) = mpsc::channel::<Message>(PROXY_CHANNEL_CAPACITY);
                 let mut client: MuxClient<TlsConnection> = MuxClient {
                     url: url.clone(),
                     conns: Vec::new(),
@@ -217,7 +218,7 @@ pub async fn new_tls_client(
     count: usize,
     idle_timeout_secs: usize,
     stream_channel_size: usize,
-) -> anyhow::Result<mpsc::UnboundedSender<Message>> {
+) -> anyhow::Result<ProxySender> {
     MuxClient::<TlsConnection>::from(
         url,
         cert_path,

--- a/src/tunnel/tls_local.rs
+++ b/src/tunnel/tls_local.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, Result};
 
 use tokio::net::TcpStream;
-use tokio::sync::mpsc;
 
+use crate::tunnel::client::ProxySender;
 use crate::tunnel::Message;
 
 /// TLS record and handshake constants (RFC 5246, RFC 6066)
@@ -354,7 +354,7 @@ pub async fn peek_sni(inbound: &mut TcpStream) -> Result<String> {
 pub async fn handle_tls(
     tunnel_id: u32,
     inbound: TcpStream,
-    sender: mpsc::UnboundedSender<Message>,
+    sender: ProxySender,
 ) -> Result<()> {
     let target_addr = match peek_sni_v2(&inbound).await {
         Ok(mut sni) => {
@@ -369,7 +369,7 @@ pub async fn handle_tls(
     } else {
         tracing::info!("[{}]Handle TLS proxy to {} ", tunnel_id, target_addr);
         let msg = Message::open_tcp_stream(inbound, target_addr, None);
-        sender.send(msg)?;
+        sender.send(msg).await?;
         Ok(())
     }
 }

--- a/src/tunnel/transparent.rs
+++ b/src/tunnel/transparent.rs
@@ -1,14 +1,14 @@
+use crate::tunnel::client::ProxySender;
 use crate::tunnel::Message;
 use crate::utils::get_original_dst;
 use anyhow::Result;
 
 use tokio::net::TcpStream;
-use tokio::sync::mpsc;
 
 pub async fn handle_transparent(
     tunnel_id: u32,
     inbound: TcpStream,
-    sender: mpsc::UnboundedSender<Message>,
+    sender: ProxySender,
 ) -> Result<()> {
     let target_addr = match get_original_dst(&inbound) {
         Ok(addr) => addr,
@@ -22,7 +22,7 @@ pub async fn handle_transparent(
         target_addr
     );
     let msg = Message::open_tcp_stream(inbound, target_addr, None);
-    sender.send(msg)?;
+    sender.send(msg).await?;
 
     Ok(())
 }

--- a/src/tunnel/udp_local.rs
+++ b/src/tunnel/udp_local.rs
@@ -1,5 +1,6 @@
 use std::{net::SocketAddr, num::NonZeroUsize};
 
+use super::client::ProxySender;
 use super::Message;
 use crate::utils::{
     new_udp_listener, LinuxTproxyUdpSocket, UdpServerStream, MAXIMUM_UDP_PAYLOAD_SIZE,
@@ -36,7 +37,7 @@ impl UdpAssociateManager {
 
 pub(crate) fn start_local_udp_tunnel_server(
     addr: &SocketAddr,
-    _msg_sender: mpsc::UnboundedSender<Message>,
+    _msg_sender: ProxySender,
 ) -> Result<(), std::io::Error> {
     let udp_socket = new_udp_listener(addr, true)?;
     let tproxy_udp_server = LinuxTproxyUdpSocket::new(udp_socket)?;


### PR DESCRIPTION
## Summary
- Replace unbounded proxy message channels with bounded `mpsc` queues (`PROXY_CHANNEL_CAPACITY=256`) for backpressure under load
- Add `--max-connections` (default 256) to cap concurrent local proxy accepts via semaphore
- Reduce mux control channel capacity (`4096` → `256`) and max event body size (`16MB` → `256KB`) for embedded/low-memory targets
- Trim tokio features (drop `full`); make `s2n_quic` opt-in (`default = []`)

## Test plan
- [x] `cargo build`
- [x] `cargo test tunnel_config`
- [x] CI