### PR TITLE
feat(mux): TLS mux flow control and WINDOW_UPDATE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Cargo.lock
 .vscode
 *.der
 *.pem
+rsnova_linux
 
 
 # Added by cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,11 +50,6 @@ lru = "0.12.5"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-# [target.'cfg(not(target_os = "windows"))'.dependencies]
-# aws-lc-rs = { version = "1", features = ["bindgen"], optional = true }
-[target.'cfg(target_arch = "arm")'.dependencies]
-aws-lc-rs = { version = "1" }
-
 [target.'cfg(not(target_arch = "arm"))'.dependencies]
 mimalloc = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "rsnova"
-version = "0.3.0"
+version = "0.1.0"
 edition = "2021"
+description = "A lightweight tunnel/proxy using TLS mux and QUIC"
+license = "Apache-2.0"
+authors = ["yinqiwen <yinqiwen@gmail.com>"]
+repository = "https://github.com/yinqiwen/rsnova"
+exclude = ["rsnova_linux", "docs/", "example/"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]
@@ -26,7 +31,7 @@ rustls-pemfile = "2"
 # rustls-native-certs = "0.7"
 anyhow = "1.0"
 url = { version = "2.5.0", features = ["serde"] }
-bincode = "2.0.0-rc.3"
+bincode = "2"
 tokio-rustls = "0.26"
 tokio-util = { version = "0.7", features = ["compat", "io", "codec", "net"] }
 httparse = "1.9"
@@ -48,10 +53,10 @@ libc = "0.2"
 # [target.'cfg(not(target_os = "windows"))'.dependencies]
 # aws-lc-rs = { version = "1", features = ["bindgen"], optional = true }
 [target.'cfg(target_arch = "arm")'.dependencies]
-aws-lc-rs = { version = "1", features = ["bindgen"] }
+aws-lc-rs = { version = "1" }
 
 [target.'cfg(not(target_arch = "arm"))'.dependencies]
-mimalloc = { version = "*" }
+mimalloc = "0.1"
 
 # [target.'cfg(target_env = "msvc")'.dependencies]
 # mimalloc = { version = "*" }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 yinqiwen
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ A Rust secure proxy and tunnel that multiplexes traffic over encrypted TLS and Q
 
 ## Quick Start
 
-### Build
+### Install
 
 ```sh
-cargo build --release
+cargo install rsnova
 ```
 
 ### 1. Generate certificates
 
 ```sh
-./target/release/rsnova --rcgen true --tls_host mydomain.io
+rsnova --rcgen true --tls_host mydomain.io
 ```
 
 This creates `cert.pem` and `key.pem` in the current directory.
@@ -46,7 +46,7 @@ This creates `cert.pem` and `key.pem` in the current directory.
 The server listens for both TLS (TCP) and QUIC (UDP) on the same address — no protocol flag required:
 
 ```sh
-./target/release/rsnova --role server --key key.pem --cert cert.pem --listen 0.0.0.0:48100
+rsnova --role server --key key.pem --cert cert.pem --listen 0.0.0.0:48100
 ```
 
 ### 3. Start the client
@@ -55,10 +55,10 @@ The client selects transport from the `--remote` URL scheme:
 
 ```sh
 # TLS
-./target/release/rsnova --role client --cert cert.pem --listen 127.0.0.1:48100 --remote tls://<server-ip>:48100 --tls_host mydomain.io
+rsnova --role client --cert cert.pem --listen 127.0.0.1:48100 --remote tls://<server-ip>:48100 --tls_host mydomain.io
 
 # QUIC
-./target/release/rsnova --role client --cert cert.pem --listen 127.0.0.1:48100 --remote quic://<server-ip>:48100 --tls_host mydomain.io
+rsnova --role client --cert cert.pem --listen 127.0.0.1:48100 --remote quic://<server-ip>:48100 --tls_host mydomain.io
 ```
 
 ### 4. Use the proxy
@@ -69,12 +69,12 @@ Point your browser or tools at `socks5://127.0.0.1:48100` or `http://127.0.0.1:4
 
 ```sh
 # Client: map local SSH (22) to remote port 2222
-./target/release/rsnova --role client --cert cert.pem --remote tls://<server-ip>:48100 \
+rsnova --role client --cert cert.pem --remote tls://<server-ip>:48100 \
   --tls_host mydomain.io --tunnel-client-id myhost \
   --tunnel 22:2222
 
 # Server: allow tunnel ports 8000-9000
-./target/release/rsnova --role server --key key.pem --cert cert.pem \
+rsnova --role server --key key.pem --cert cert.pem \
   --listen 0.0.0.0:48100 --tunnel-port-range 8000-9000
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,55 +1,57 @@
 # rsnova
 
-Rust 实现的安全代理/隧道工具，基于 QUIC 和 TLS 协议提供多路复用的网络隧道。
+[简体中文](README.zh-CN.md)
 
-## 特性
+A Rust secure proxy and tunnel that multiplexes traffic over encrypted TLS and QUIC connections.
 
-- **加密传输** — 支持 TLS (rustls) 和 QUIC (s2n-quic) 两种加密隧道协议，服务端同时监听
-- **多协议代理** — 自动识别 SOCKS5、HTTP/HTTPS、TLS SNI 协议，无法识别时回退到透明代理
-- **流多路复用** — 单条连接上承载多个数据流，内置背压控制和连接池
-- **NAT 穿透** — 反向隧道模式，将内网服务暴露到公网，支持 SNI 域名路由
-- **透明代理** — Linux 下支持 `SO_ORIGINAL_DST` / tproxy（TCP + UDP）
-- **自签证书** — 内置 `--rcgen` 一键生成 TLS 证书
-- **后台运行** — Unix 下支持 `-d` 守护进程模式
-- **日志轮转** — `--log` 指定日志文件，自动按天轮转
-- **监控接口** — 内置 Admin HTTP 服务，提供 `/metrics` 端点
+## Features
 
-## 使用场景
+- **Encrypted transport** — TLS (rustls) and QUIC (s2n-quic); the server listens on both simultaneously
+- **Multi-protocol proxy** — Auto-detects SOCKS5, HTTP/HTTPS, and TLS SNI; falls back to transparent proxy
+- **Stream multiplexing** — Many logical streams over one connection, with WINDOW_UPDATE flow control and a connection pool
+- **NAT traversal** — Reverse tunnel mode to expose local services on a public server, with optional SNI routing
+- **Transparent proxy** — Linux `SO_ORIGINAL_DST` / tproxy support (TCP + UDP)
+- **Self-signed certs** — Built-in `--rcgen` certificate generation
+- **Daemon mode** — Background execution on Unix (`-d`)
+- **Log rotation** — Daily rotation via `--log`
+- **Admin HTTP** — Built-in `/metrics` and `/config` endpoints
 
-| 场景 | 说明 |
-|------|------|
-| 安全代理 | 客户端提供 SOCKS5/HTTP 代理入口，通过加密隧道转发到服务端访问目标网络 |
-| 内网穿透 | 将内网服务（SSH、数据库、Web 等）通过反向隧道暴露到公网服务器 |
-| 透明代理 | Linux 网关上配合 iptables/nftables 做透明代理，无需客户端配置 |
-| TLS SNI 路由 | 根据 TLS ClientHello 中的 SNI 域名路由到不同后端服务 |
+## Use Cases
 
-## 使用说明
+| Scenario | Description |
+|----------|-------------|
+| Secure proxy | Client exposes SOCKS5/HTTP locally; traffic is forwarded through an encrypted tunnel to reach targets on the server side |
+| NAT traversal | Expose internal services (SSH, databases, web apps) on a public host via reverse tunnels |
+| Transparent proxy | Gateway transparent proxy on Linux with iptables/nftables, no client configuration |
+| TLS SNI routing | Route by SNI hostname from TLS ClientHello to different backend services |
 
-### 构建
+## Quick Start
+
+### Build
 
 ```sh
 cargo build --release
 ```
 
-### 1. 生成证书
+### 1. Generate certificates
 
 ```sh
 ./target/release/rsnova --rcgen true --tls_host mydomain.io
 ```
 
-生成 `cert.pem` 和 `key.pem`。
+This creates `cert.pem` and `key.pem` in the current directory.
 
-### 2. 启动服务端
+### 2. Start the server
 
-服务端同时监听 TLS (TCP) 和 QUIC (UDP)，无需指定协议：
+The server listens for both TLS (TCP) and QUIC (UDP) on the same address — no protocol flag required:
 
 ```sh
 ./target/release/rsnova --role server --key key.pem --cert cert.pem --listen 0.0.0.0:48100
 ```
 
-### 3. 启动客户端
+### 3. Start the client
 
-客户端根据 `--remote` 的 URL scheme 自动选择协议：
+The client selects transport from the `--remote` URL scheme:
 
 ```sh
 # TLS
@@ -59,36 +61,36 @@ cargo build --release
 ./target/release/rsnova --role client --cert cert.pem --listen 127.0.0.1:48100 --remote quic://<server-ip>:48100 --tls_host mydomain.io
 ```
 
-### 4. 使用代理
+### 4. Use the proxy
 
-浏览器或工具配置代理为 `socks5://127.0.0.1:48100` 或 `http://127.0.0.1:48100`。
+Point your browser or tools at `socks5://127.0.0.1:48100` or `http://127.0.0.1:48100`.
 
-### NAT 穿透（反向隧道）
+### NAT Traversal (Reverse Tunnel)
 
 ```sh
-# 客户端：将本地 SSH (22) 映射到服务端 2222 端口
+# Client: map local SSH (22) to remote port 2222
 ./target/release/rsnova --role client --cert cert.pem --remote tls://<server-ip>:48100 \
   --tls_host mydomain.io --tunnel-client-id myhost \
   --tunnel 22:2222
 
-# 服务端：允许隧道使用 8000-9000 端口
+# Server: allow tunnel ports 8000-9000
 ./target/release/rsnova --role server --key key.pem --cert cert.pem \
   --listen 0.0.0.0:48100 --tunnel-port-range 8000-9000
 ```
 
-隧道格式：
+Tunnel entry formats:
 
-| 格式 | 说明 |
-|------|------|
-| `port` | localhost:port → 远端同端口 |
-| `localPort:remotePort` | localhost:localPort → 远端 remotePort |
-| `host:localPort:remotePort` | host:localPort → 远端 remotePort |
-| `host:localPort:remotePort:sni` | 同上，附带 SNI 域名路由 |
-| `[ipv6]:localPort:remotePort[:sni]` | IPv6 地址支持 |
+| Format | Description |
+|--------|-------------|
+| `port` | localhost:port → same port on server |
+| `localPort:remotePort` | localhost:localPort → server remotePort |
+| `host:localPort:remotePort` | host:localPort → server remotePort |
+| `host:localPort:remotePort:sni` | Same as above, with SNI domain routing |
+| `[ipv6]:localPort:remotePort[:sni]` | IPv6 host support |
 
-### 配置文件
+### Configuration File
 
-支持 TOML 配置文件（`-c config.toml`），CLI 参数优先级高于配置文件：
+All options can be set in a TOML file (`-c config.toml`). CLI arguments override file values:
 
 ```toml
 listen = "127.0.0.1:48100"
@@ -99,23 +101,26 @@ key = "key.pem"
 tls_host = "mydomain.io"
 concurrent = 5
 threads = 2
-idle_timeout_secs = 30
+idle_timeout_secs = 120
+mux_stream_window = 262144
 max_connections = 256
 admin_listen = "127.0.0.1:48102"
 ```
 
-### 常用参数
+### Common Options
 
-| 参数 | 默认值 | 说明 |
-|------|--------|------|
-| `--listen` | `127.0.0.1:48100` | 代理监听地址 |
-| `--role` | `client` | `client` 或 `server` |
-| `--remote` | — | 远端地址 (`tls://host:port` 或 `quic://host:port`) |
-| `--concurrent` | `5` | 连接池大小 |
-| `--max-connections` | `256` | 最大并发代理连接数 |
-| `--tunnel` | — | 隧道条目（与 `--listen`/`--tproxy` 互斥） |
-| `--tunnel-port-range` | — | 服务端允许的端口范围，如 `8000-9000,10000-10100` |
-| `--tproxy` | `false` | 透明代理模式 (Linux) |
-| `-d, --daemon` | `false` | 后台运行 (Unix) |
-| `--log` | — | 日志文件路径 |
-| `-c, --config` | — | TOML 配置文件路径 |
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--listen` | `127.0.0.1:48100` | Local proxy listen address |
+| `--role` | `client` | `client` or `server` |
+| `--remote` | — | Remote URL (`tls://host:port` or `quic://host:port`) |
+| `--concurrent` | `5` | Connection pool size |
+| `--max-connections` | `256` | Max concurrent proxy connections |
+| `--idle-timeout-secs` | `120` | Idle timeout per relay (seconds) |
+| `--mux-stream-window` | `262144` | TLS mux per-stream flow-control window (bytes) |
+| `--tunnel` | — | Tunnel entries (conflicts with `--listen` / `--tproxy`) |
+| `--tunnel-port-range` | — | Allowed port ranges on server, e.g. `8000-9000,10000-10100` |
+| `--tproxy` | `false` | Transparent proxy mode (Linux) |
+| `-d, --daemon` | `false` | Run in background (Unix) |
+| `--log` | — | Log file path |
+| `-c, --config` | — | TOML config file path |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,16 +27,16 @@ Rust 实现的安全代理/隧道工具，基于 QUIC 和 TLS 协议提供多路
 
 ## 使用说明
 
-### 构建
+### 安装
 
 ```sh
-cargo build --release
+cargo install rsnova
 ```
 
 ### 1. 生成证书
 
 ```sh
-./target/release/rsnova --rcgen true --tls_host mydomain.io
+rsnova --rcgen true --tls_host mydomain.io
 ```
 
 生成 `cert.pem` 和 `key.pem`。
@@ -46,7 +46,7 @@ cargo build --release
 服务端同时监听 TLS (TCP) 和 QUIC (UDP)，无需指定协议：
 
 ```sh
-./target/release/rsnova --role server --key key.pem --cert cert.pem --listen 0.0.0.0:48100
+rsnova --role server --key key.pem --cert cert.pem --listen 0.0.0.0:48100
 ```
 
 ### 3. 启动客户端
@@ -55,10 +55,10 @@ cargo build --release
 
 ```sh
 # TLS
-./target/release/rsnova --role client --cert cert.pem --listen 127.0.0.1:48100 --remote tls://<server-ip>:48100 --tls_host mydomain.io
+rsnova --role client --cert cert.pem --listen 127.0.0.1:48100 --remote tls://<server-ip>:48100 --tls_host mydomain.io
 
 # QUIC
-./target/release/rsnova --role client --cert cert.pem --listen 127.0.0.1:48100 --remote quic://<server-ip>:48100 --tls_host mydomain.io
+rsnova --role client --cert cert.pem --listen 127.0.0.1:48100 --remote quic://<server-ip>:48100 --tls_host mydomain.io
 ```
 
 ### 4. 使用代理
@@ -69,12 +69,12 @@ cargo build --release
 
 ```sh
 # 客户端：将本地 SSH (22) 映射到服务端 2222 端口
-./target/release/rsnova --role client --cert cert.pem --remote tls://<server-ip>:48100 \
+rsnova --role client --cert cert.pem --remote tls://<server-ip>:48100 \
   --tls_host mydomain.io --tunnel-client-id myhost \
   --tunnel 22:2222
 
 # 服务端：允许隧道使用 8000-9000 端口
-./target/release/rsnova --role server --key key.pem --cert cert.pem \
+rsnova --role server --key key.pem --cert cert.pem \
   --listen 0.0.0.0:48100 --tunnel-port-range 8000-9000
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,126 @@
+# rsnova
+
+[English](README.md)
+
+Rust 实现的安全代理/隧道工具，基于 QUIC 和 TLS 协议提供多路复用的网络隧道。
+
+## 特性
+
+- **加密传输** — 支持 TLS (rustls) 和 QUIC (s2n-quic) 两种加密隧道协议，服务端同时监听
+- **多协议代理** — 自动识别 SOCKS5、HTTP/HTTPS、TLS SNI 协议，无法识别时回退到透明代理
+- **流多路复用** — 单条连接上承载多个数据流，内置流控（WINDOW_UPDATE）和连接池
+- **NAT 穿透** — 反向隧道模式，将内网服务暴露到公网，支持 SNI 域名路由
+- **透明代理** — Linux 下支持 `SO_ORIGINAL_DST` / tproxy（TCP + UDP）
+- **自签证书** — 内置 `--rcgen` 一键生成 TLS 证书
+- **后台运行** — Unix 下支持 `-d` 守护进程模式
+- **日志轮转** — `--log` 指定日志文件，自动按天轮转
+- **监控接口** — 内置 Admin HTTP 服务，提供 `/metrics` 和 `/config` 端点
+
+## 使用场景
+
+| 场景 | 说明 |
+|------|------|
+| 安全代理 | 客户端提供 SOCKS5/HTTP 代理入口，通过加密隧道转发到服务端访问目标网络 |
+| 内网穿透 | 将内网服务（SSH、数据库、Web 等）通过反向隧道暴露到公网服务器 |
+| 透明代理 | Linux 网关上配合 iptables/nftables 做透明代理，无需客户端配置 |
+| TLS SNI 路由 | 根据 TLS ClientHello 中的 SNI 域名路由到不同后端服务 |
+
+## 使用说明
+
+### 构建
+
+```sh
+cargo build --release
+```
+
+### 1. 生成证书
+
+```sh
+./target/release/rsnova --rcgen true --tls_host mydomain.io
+```
+
+生成 `cert.pem` 和 `key.pem`。
+
+### 2. 启动服务端
+
+服务端同时监听 TLS (TCP) 和 QUIC (UDP)，无需指定协议：
+
+```sh
+./target/release/rsnova --role server --key key.pem --cert cert.pem --listen 0.0.0.0:48100
+```
+
+### 3. 启动客户端
+
+客户端根据 `--remote` 的 URL scheme 自动选择协议：
+
+```sh
+# TLS
+./target/release/rsnova --role client --cert cert.pem --listen 127.0.0.1:48100 --remote tls://<server-ip>:48100 --tls_host mydomain.io
+
+# QUIC
+./target/release/rsnova --role client --cert cert.pem --listen 127.0.0.1:48100 --remote quic://<server-ip>:48100 --tls_host mydomain.io
+```
+
+### 4. 使用代理
+
+浏览器或工具配置代理为 `socks5://127.0.0.1:48100` 或 `http://127.0.0.1:48100`。
+
+### NAT 穿透（反向隧道）
+
+```sh
+# 客户端：将本地 SSH (22) 映射到服务端 2222 端口
+./target/release/rsnova --role client --cert cert.pem --remote tls://<server-ip>:48100 \
+  --tls_host mydomain.io --tunnel-client-id myhost \
+  --tunnel 22:2222
+
+# 服务端：允许隧道使用 8000-9000 端口
+./target/release/rsnova --role server --key key.pem --cert cert.pem \
+  --listen 0.0.0.0:48100 --tunnel-port-range 8000-9000
+```
+
+隧道格式：
+
+| 格式 | 说明 |
+|------|------|
+| `port` | localhost:port → 远端同端口 |
+| `localPort:remotePort` | localhost:localPort → 远端 remotePort |
+| `host:localPort:remotePort` | host:localPort → 远端 remotePort |
+| `host:localPort:remotePort:sni` | 同上，附带 SNI 域名路由 |
+| `[ipv6]:localPort:remotePort[:sni]` | IPv6 地址支持 |
+
+### 配置文件
+
+支持 TOML 配置文件（`-c config.toml`），CLI 参数优先级高于配置文件：
+
+```toml
+listen = "127.0.0.1:48100"
+role = "client"
+remote = "tls://1.2.3.4:48100"
+cert = "cert.pem"
+key = "key.pem"
+tls_host = "mydomain.io"
+concurrent = 5
+threads = 2
+idle_timeout_secs = 120
+mux_stream_window = 262144
+max_connections = 256
+admin_listen = "127.0.0.1:48102"
+```
+
+### 常用参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--listen` | `127.0.0.1:48100` | 代理监听地址 |
+| `--role` | `client` | `client` 或 `server` |
+| `--remote` | — | 远端地址 (`tls://host:port` 或 `quic://host:port`) |
+| `--concurrent` | `5` | 连接池大小 |
+| `--max-connections` | `256` | 最大并发代理连接数 |
+| `--idle-timeout-secs` | `120` | 连接空闲超时（秒） |
+| `--mux-stream-window` | `262144` | TLS mux 每流流控窗口（字节） |
+| `--tunnel` | — | 隧道条目（与 `--listen`/`--tproxy` 互斥） |
+| `--tunnel-port-range` | — | 服务端允许的端口范围，如 `8000-9000,10000-10100` |
+| `--tproxy` | `false` | 透明代理模式 (Linux) |
+| `-d, --daemon` | `false` | 后台运行 (Unix) |
+| `--log` | — | 日志文件路径 |
+| `-c, --config` | — | TOML 配置文件路径 |

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ enum Role {
 
 /// Outer CLI struct: only handles --config path and forwards the rest
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("CARGO_PKG_AUTHORS"), ")"), about, long_about = None)]
 struct Cli {
     /// Config file path (TOML format)
     #[arg(short, long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,10 +99,10 @@ struct Args {
     #[arg(long)]
     idle_timeout_secs: usize,
 
-    /// Per-stream mux inbound channel size (TLS protocol only)
-    #[default(mux::DEFAULT_STREAM_CHANNEL_SIZE)]
+    /// Per-stream flow control window in bytes (TLS protocol only)
+    #[default(mux::INITIAL_STREAM_WINDOW)]
     #[arg(long)]
-    mux_stream_channel_size: usize,
+    mux_stream_window: u32,
 
     #[default("mydomain.io".to_string())]
     #[arg(long)]
@@ -201,7 +201,9 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
 
     let tunnel_entries = if !args.tunnel.is_empty() {
         if args.tunnel_client_id.is_empty() {
-            return Err(anyhow!("--tunnel-client-id is required when --tunnel is specified"));
+            return Err(anyhow!(
+                "--tunnel-client-id is required when --tunnel is specified"
+            ));
         }
         let mut entries = Vec::new();
         for t in &args.tunnel {
@@ -213,7 +215,9 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
     };
 
     let tunnel_port_ranges = if !args.tunnel_port_range.is_empty() {
-        Some(tunnel::tunnel_config::parse_port_range(&args.tunnel_port_range)?)
+        Some(tunnel::tunnel_config::parse_port_range(
+            &args.tunnel_port_range,
+        )?)
     } else {
         None
     };
@@ -248,7 +252,9 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
             admin_listen: args.admin_listen.to_string(),
             tproxy: args.tproxy,
         },
-        reload_token: Arc::new(tokio::sync::Mutex::new(tokio_util::sync::CancellationToken::new())),
+        reload_token: Arc::new(tokio::sync::Mutex::new(
+            tokio_util::sync::CancellationToken::new(),
+        )),
     });
 
     // Start admin server (always enabled)
@@ -278,7 +284,7 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
                     &args.cert,
                     &args.tls_host,
                     args.idle_timeout_secs,
-                    args.mux_stream_channel_size,
+                    args.mux_stream_window,
                     app_config,
                 )
                 .await?;
@@ -304,7 +310,7 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
                             &args.tls_host,
                             args.concurrent,
                             args.idle_timeout_secs,
-                            args.mux_stream_channel_size,
+                            args.mux_stream_window,
                         )
                         .await?
                     }
@@ -330,7 +336,14 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
             let tproxy = args.tproxy;
             let max_connections = args.max_connections;
             tokio::spawn(async move {
-                if let Err(e) = tunnel::start_local_tunnel_server(&listen_addr, tunnel_sender, tproxy, max_connections).await {
+                if let Err(e) = tunnel::start_local_tunnel_server(
+                    &listen_addr,
+                    tunnel_sender,
+                    tproxy,
+                    max_connections,
+                )
+                .await
+                {
                     tracing::error!("local tunnel server error: {e:?}");
                 }
             });
@@ -359,7 +372,7 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
             let quic_cert = args.cert.clone();
             let quic_key = args.key.clone();
             let idle = args.idle_timeout_secs;
-            let channel_size = args.mux_stream_channel_size;
+            let stream_window = args.mux_stream_window;
             let tls_registry = registry.clone();
 
             let tls_handle = tokio::spawn(async move {
@@ -368,7 +381,7 @@ async fn service_main(args: &Args) -> anyhow::Result<()> {
                     &tls_cert,
                     &tls_key,
                     idle,
-                    channel_size,
+                    stream_window,
                     tls_registry,
                 )
                 .await
@@ -418,7 +431,10 @@ fn main() {
                 .unwrap_or_else(|e| panic!("Invalid TOML in {:?}: {}", config_path, e));
             Args::from(file_config).merge(&mut cli.args)
         } else {
-            eprintln!("Warning: config file {:?} not found, using CLI args only", config_path);
+            eprintln!(
+                "Warning: config file {:?} not found, using CLI args only",
+                config_path
+            );
             Args::from(&mut cli.args)
         }
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,7 @@ struct Args {
     #[arg(long)]
     thread_stack_size: usize,
 
-    #[default(30)]
+    #[default(120)]
     #[arg(long)]
     idle_timeout_secs: usize,
 

--- a/src/mux/connection.rs
+++ b/src/mux/connection.rs
@@ -23,6 +23,10 @@ struct StreamEntry {
     sender: mpsc::UnboundedSender<Option<Bytes>>,
     recv_window: u32,
     flow: Arc<StreamFlow>,
+    /// Bytes pushed into unbounded channel but not yet consumed by MuxStream.
+    /// Incremented on sender.send(), decremented when WindowUpdateToPeer fires
+    /// (which means MuxStream read data and released window).
+    pending_bytes: u64,
 }
 
 pub struct Connection {
@@ -187,6 +191,7 @@ async fn handle_mux_connection<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                             sender: params.sender,
                             recv_window: initial_stream_window,
                             flow: params.flow.clone(),
+                            pending_bytes: 0,
                         });
                         metrics::increment_gauge!("mux.streams", 1.0);
                         if let Some(rx) = params.receiver {
@@ -227,6 +232,7 @@ async fn handle_mux_connection<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                                 let _ = event::write_event(&mut w, ev).await;
                             } else {
                                 entry.recv_window -= data_len;
+                                entry.pending_bytes += data_len as u64;
                                 if entry.sender.send(Some(data)).is_err() {
                                     tracing::error!(
                                         "[{}/{}] stream receiver dropped",
@@ -254,6 +260,7 @@ async fn handle_mux_connection<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                 }
                 Control::WindowUpdateToPeer(sid, increment) => {
                     if let Some(entry) = stream_entries.get_mut(&sid) {
+                        entry.pending_bytes = entry.pending_bytes.saturating_sub(increment as u64);
                         entry.recv_window = entry
                             .recv_window
                             .saturating_add(increment)
@@ -307,6 +314,19 @@ async fn handle_mux_connection<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                 let _ = accept_callback.unwrap().send(Ok(stream));
                 accept_callback = None;
             }
+
+            // Aggregate flow control and channel depth metrics across all streams.
+            let mut total_recv_window: u64 = 0;
+            let mut total_send_window: u64 = 0;
+            let mut total_pending_bytes: u64 = 0;
+            for entry in stream_entries.values() {
+                total_recv_window += entry.recv_window as u64;
+                total_send_window += entry.flow.available() as u64;
+                total_pending_bytes += entry.pending_bytes;
+            }
+            metrics::gauge!("mux.stream.total_recv_window", total_recv_window as f64);
+            metrics::gauge!("mux.stream.total_send_window", total_send_window as f64);
+            metrics::gauge!("mux.stream.total_pending_bytes", total_pending_bytes as f64);
         }
 
         metrics::decrement_gauge!("mux.streams", stream_entries.len() as f64);

--- a/src/mux/connection.rs
+++ b/src/mux/connection.rs
@@ -1,24 +1,34 @@
-use crate::mux::stream::MuxStream;
+use crate::mux::stream::{MuxStream, StreamFlow};
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
 use super::event;
+use super::stream::{Control, NewStreamParams};
 
-use super::stream::Control;
-
-pub const DEFAULT_STREAM_CHANNEL_SIZE: usize = 16;
+pub const INITIAL_STREAM_WINDOW: u32 = 256 * 1024;
+/// Documentation only — actual threshold is computed per-MuxStream as initial_stream_window / 2.
+#[allow(dead_code)]
+pub const WINDOW_UPDATE_THRESHOLD: u32 = INITIAL_STREAM_WINDOW / 2;
 pub const CONTROL_CHANNEL_CAPACITY: usize = 256;
+
+/// Per-stream state owned exclusively by the dispatcher.
+struct StreamEntry {
+    sender: mpsc::UnboundedSender<Option<Bytes>>,
+    recv_window: u32,
+    flow: Arc<StreamFlow>,
+}
 
 pub struct Connection {
     ev_writer: mpsc::Sender<Control>,
     stream_id_seed: AtomicU32,
-    stream_channel_size: usize,
+    initial_stream_window: u32,
 }
 
 pub enum Mode {
@@ -27,7 +37,7 @@ pub enum Mode {
 }
 
 impl Connection {
-    pub fn new_with_stream_channel_size<
+    pub fn new_with_stream_window<
         R: AsyncRead + Unpin + Send + 'static,
         W: AsyncWrite + Unpin + Send + 'static,
     >(
@@ -35,45 +45,60 @@ impl Connection {
         w: W,
         mode: Mode,
         id: u32,
-        stream_channel_size: usize,
+        stream_window: u32,
     ) -> Self {
         let (sender_orig, receiver) = mpsc::channel::<Control>(CONTROL_CHANNEL_CAPACITY);
         let sender = sender_orig.clone();
         tokio::spawn(async move {
-            handle_mux_connection(id, r, w, receiver, sender, stream_channel_size).await;
+            handle_mux_connection(id, r, w, receiver, sender, stream_window).await;
         });
         match mode {
             Mode::Client => Self {
                 ev_writer: sender_orig,
                 stream_id_seed: AtomicU32::new(0),
-                stream_channel_size,
+                initial_stream_window: stream_window,
             },
             Mode::Server => Self {
                 ev_writer: sender_orig,
                 stream_id_seed: AtomicU32::new(1),
-                stream_channel_size,
+                initial_stream_window: stream_window,
             },
         }
     }
+
     pub async fn ping(&self) -> Result<()> {
         if let Err(e) = self.ev_writer.send(Control::Ping).await {
             return Err(anyhow::Error::new(e));
         }
         Ok(())
     }
+
     pub async fn open_stream(&self) -> Result<MuxStream> {
-        let (sender, receiver) = mpsc::channel::<Option<Bytes>>(self.stream_channel_size);
+        let (sender, receiver) = mpsc::unbounded_channel::<Option<Bytes>>();
+        let flow = Arc::new(StreamFlow::new(self.initial_stream_window));
         let id = self.stream_id_seed.fetch_add(2, Ordering::SeqCst);
-        let stream = MuxStream::new(id, self.ev_writer.clone(), receiver);
+        let stream = MuxStream::new(
+            id,
+            self.ev_writer.clone(),
+            receiver,
+            flow.clone(),
+            self.initial_stream_window,
+        );
         if let Err(e) = self
             .ev_writer
-            .send(Control::NewStream((id, sender, None)))
+            .send(Control::NewStream(NewStreamParams {
+                stream_id: id,
+                sender,
+                receiver: None,
+                flow,
+            }))
             .await
         {
             return Err(anyhow::Error::new(e));
         }
         Ok(stream)
     }
+
     pub async fn accept_stream(&self) -> Result<MuxStream> {
         let (sender, receiver) = oneshot::channel::<Result<MuxStream>>();
         if let Err(e) = self.ev_writer.send(Control::AcceptStream(sender)).await {
@@ -92,57 +117,47 @@ async fn handle_mux_connection<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     mut w: W,
     mut ev_reader: mpsc::Receiver<Control>,
     ev_writer_orig: mpsc::Sender<Control>,
-    stream_channel_size: usize,
+    initial_stream_window: u32,
 ) {
     let ev_writer = ev_writer_orig.clone();
     let read_connection_fut = async move {
         let mut buf_reader = tokio::io::BufReader::new(r);
         while let Ok(ev) = event::read_event(&mut buf_reader).await {
-            match ev.header.flags() {
+            let ctrl = match ev.header.flags() {
                 event::FLAG_SYN => {
-                    let (sender, receiver) = mpsc::channel::<Option<Bytes>>(stream_channel_size);
-                    let ctrl = Control::NewStream((ev.header.stream_id, sender, Some(receiver)));
-                    if ev_writer.send(ctrl).await.is_err() {
-                        break;
+                    let (sender, receiver) = mpsc::unbounded_channel::<Option<Bytes>>();
+                    let flow = Arc::new(StreamFlow::new(initial_stream_window));
+                    Control::NewStream(NewStreamParams {
+                        stream_id: ev.header.stream_id,
+                        sender,
+                        receiver: Some(receiver),
+                        flow,
+                    })
+                }
+                event::FLAG_FIN => Control::StreamClose(ev.header.stream_id, true),
+                event::FLAG_SHUTDOWN => Control::StreamShutdown(ev.header.stream_id, true),
+                event::FLAG_DATA => Control::StreamData(ev.header.stream_id, ev.body, true),
+                event::FLAG_PING => continue,
+                event::FLAG_WIN_UPDATE => {
+                    if ev.body.len() == 4 {
+                        let increment = u32::from_le_bytes(ev.body[..4].try_into().unwrap());
+                        Control::WindowUpdateFromPeer(ev.header.stream_id, increment)
+                    } else {
+                        continue;
                     }
                 }
-                event::FLAG_FIN => {
-                    if ev_writer
-                        .send(Control::StreamClose(ev.header.stream_id, true))
-                        .await
-                        .is_err()
-                    {
-                        break;
-                    }
-                }
-                event::FLAG_SHUTDOWN => {
-                    if ev_writer
-                        .send(Control::StreamShutdown(ev.header.stream_id, true))
-                        .await
-                        .is_err()
-                    {
-                        break;
-                    }
-                }
-                event::FLAG_DATA => {
-                    if ev_writer
-                        .send(Control::StreamData(ev.header.stream_id, ev.body, true))
-                        .await
-                        .is_err()
-                    {
-                        break;
-                    }
-                }
-                event::FLAG_PING => {
-                    //
-                }
+                // FLAG_AUTH/AUTH_ACK/OPEN/REVERSE_OPEN payloads travel via FLAG_DATA at app layer.
                 _ => {
                     tracing::error!(
                         "Unexpected event:{}/{}",
                         ev.header.flags(),
                         ev.header.stream_id
                     );
+                    continue;
                 }
+            };
+            if ev_writer.send(ctrl).await.is_err() {
+                break;
             }
         }
         let _ = ev_writer.send(Control::Close).await;
@@ -150,10 +165,9 @@ async fn handle_mux_connection<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 
     let ev_writer = ev_writer_orig.clone();
     let read_ctrl_fut = async move {
-        //let labels: [(&str, String); 1] = [("idx", format!("{}", conn_id))];
         let mut incoming_streams: VecDeque<MuxStream> = VecDeque::new();
         let mut accept_callback: Option<oneshot::Sender<Result<MuxStream>>> = None;
-        let mut stream_senders: HashMap<u32, mpsc::Sender<Option<Bytes>>> = HashMap::new();
+        let mut stream_entries: HashMap<u32, StreamEntry> = HashMap::new();
 
         while let Some(ctrl) = ev_reader.recv().await {
             match ctrl {
@@ -164,19 +178,28 @@ async fn handle_mux_connection<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                     }
                     accept_callback = Some(callback);
                 }
-                Control::NewStream((sid, sender, receiver)) => match stream_senders.entry(sid) {
-                    Entry::Occupied(e) => {
-                        tracing::error!("Duplicate stream id:{}", sid);
-                        let _ = e.get().send(Some(Bytes::new())).await;
+                Control::NewStream(params) => match stream_entries.entry(params.stream_id) {
+                    Entry::Occupied(_) => {
+                        tracing::error!("Duplicate stream id:{}", params.stream_id);
                     }
                     Entry::Vacant(v) => {
-                        v.insert(sender);
+                        v.insert(StreamEntry {
+                            sender: params.sender,
+                            recv_window: initial_stream_window,
+                            flow: params.flow.clone(),
+                        });
                         metrics::increment_gauge!("mux.streams", 1.0);
-                        if receiver.is_some() {
-                            let stream = MuxStream::new(sid, ev_writer.clone(), receiver.unwrap());
+                        if let Some(rx) = params.receiver {
+                            let stream = MuxStream::new(
+                                params.stream_id,
+                                ev_writer.clone(),
+                                rx,
+                                params.flow,
+                                initial_stream_window,
+                            );
                             incoming_streams.push_back(stream);
                         } else {
-                            let ev = event::new_syn_event(sid);
+                            let ev = event::new_syn_event(params.stream_id);
                             if let Err(e) = event::write_event(&mut w, ev).await {
                                 tracing::error!("write syn failed:{}", e);
                                 break;
@@ -185,73 +208,85 @@ async fn handle_mux_connection<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                     }
                 },
                 Control::StreamData(sid, data, incoming) => {
-                    match stream_senders.get(&sid) {
-                        Some(stream_sender) => {
-                            if incoming {
-                                let data_len = data.len();
-                                if let Err(e) = stream_sender.send(Some(data)).await {
-                                    // handle error
-                                    tracing::error!(
-                                        "Stream:{}/{} send error:{} with data len:{}",
-                                        conn_id,
-                                        sid,
-                                        e,
-                                        data_len
-                                    );
-                                }
+                    if incoming {
+                        if let Some(entry) = stream_entries.get_mut(&sid) {
+                            let data_len = data.len() as u32;
+                            if data_len > entry.recv_window {
+                                tracing::error!(
+                                    "[{}/{}] flow control violation: {} > recv_window {}",
+                                    conn_id,
+                                    sid,
+                                    data_len,
+                                    entry.recv_window
+                                );
+                                entry.flow.close();
+                                let _ = entry.sender.send(None);
+                                stream_entries.remove(&sid);
+                                metrics::decrement_gauge!("mux.streams", 1.0);
+                                let ev = event::new_fin_event(sid);
+                                let _ = event::write_event(&mut w, ev).await;
                             } else {
-                                let ev = event::new_data_event(sid, data);
-                                if let Err(e) = event::write_event(&mut w, ev).await {
-                                    tracing::error!("write stream data failed:{}", e);
-                                    break;
+                                entry.recv_window -= data_len;
+                                if entry.sender.send(Some(data)).is_err() {
+                                    tracing::error!(
+                                        "[{}/{}] stream receiver dropped",
+                                        conn_id,
+                                        sid
+                                    );
+                                    entry.flow.close();
+                                    stream_entries.remove(&sid);
+                                    metrics::decrement_gauge!("mux.streams", 1.0);
                                 }
                             }
                         }
-                        None => {
-                            if !data.is_empty() {
-                                tracing::error!(
-                                    "No stream:{}/{} found for for data incoming:{} with data len:{}",
-                                    conn_id,sid,
-                                    incoming,
-                                    data.len()
-                                );
-                            }
+                    } else {
+                        let ev = event::new_data_event(sid, data);
+                        if let Err(e) = event::write_event(&mut w, ev).await {
+                            tracing::error!("write stream data failed:{}", e);
+                            break;
+                        }
+                    }
+                }
+                Control::WindowUpdateFromPeer(sid, increment) => {
+                    if let Some(entry) = stream_entries.get(&sid) {
+                        entry.flow.credit(increment);
+                    }
+                }
+                Control::WindowUpdateToPeer(sid, increment) => {
+                    if let Some(entry) = stream_entries.get_mut(&sid) {
+                        entry.recv_window = entry
+                            .recv_window
+                            .saturating_add(increment)
+                            .min(initial_stream_window);
+                        let ev = event::new_window_update_event(sid, increment);
+                        if let Err(e) = event::write_event(&mut w, ev).await {
+                            tracing::error!("write window update failed:{}", e);
+                            break;
                         }
                     }
                 }
                 Control::StreamShutdown(sid, remote) => {
-                    tracing::info!(
-                        "[{}/{}]Stream shutdown write from remote:{}",
-                        conn_id,
-                        sid,
-                        remote
-                    );
-                    if let Some(sender) = stream_senders.get(&sid) {
+                    if let Some(entry) = stream_entries.get(&sid) {
                         if !remote {
                             let ev = event::new_shutdown_event(sid);
                             if let Err(e) = event::write_event(&mut w, ev).await {
-                                tracing::error!("write fin failed:{}", e);
+                                tracing::error!("write shutdown failed:{}", e);
                                 break;
                             }
                         } else {
-                            let _ = sender.send(Some(Bytes::new())).await;
+                            let _ = entry.sender.send(Some(Bytes::new()));
                         }
                     }
                 }
                 Control::StreamClose(sid, remote) => {
-                    tracing::info!("[{}/{}]Stream close from remote:{}", conn_id, sid, remote);
-                    match stream_senders.remove_entry(&sid) {
-                        Some((_, sender)) => {
-                            metrics::decrement_gauge!("mux.streams", 1.0);
-                            if !remote {
-                                let ev = event::new_fin_event(sid);
-                                let _ = event::write_event(&mut w, ev).await;
-                            } else {
-                                let _ = sender.send(None).await;
-                            }
-                        }
-                        None => {
-                            //
+                    if let Some(entry) = stream_entries.remove(&sid) {
+                        metrics::decrement_gauge!("mux.streams", 1.0);
+                        entry.flow.close();
+                        if !remote {
+                            let ev = event::new_fin_event(sid);
+                            let _ = event::write_event(&mut w, ev).await;
+                        } else {
+                            let _ = entry.sender.send(None);
                         }
                     }
                 }
@@ -274,16 +309,13 @@ async fn handle_mux_connection<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             }
         }
 
-        //close streams
-        metrics::decrement_gauge!("mux.streams", stream_senders.len() as f64);
-        for (_, sender) in stream_senders.drain() {
-            let _ = sender.send(None).await;
+        metrics::decrement_gauge!("mux.streams", stream_entries.len() as f64);
+        for (_, entry) in stream_entries.drain() {
+            entry.flow.close();
+            let _ = entry.sender.send(None);
         }
-        if accept_callback.is_some() {
-            let _ = accept_callback
-                .unwrap()
-                .send(Err(anyhow!("connection closed")));
-            //accept_callback = None;
+        if let Some(cb) = accept_callback {
+            let _ = cb.send(Err(anyhow!("connection closed")));
         }
     };
     tokio::join!(read_connection_fut, read_ctrl_fut);

--- a/src/mux/event.rs
+++ b/src/mux/event.rs
@@ -14,6 +14,7 @@ pub const FLAG_SHUTDOWN: u8 = 7;
 pub const FLAG_AUTH: u8 = 6;
 pub const FLAG_AUTH_ACK: u8 = 9;
 pub const FLAG_REVERSE_OPEN: u8 = 10;
+pub const FLAG_WIN_UPDATE: u8 = 8;
 
 pub const EVENT_HEADER_LEN: usize = 8;
 pub const MAX_EVENT_BODY_LEN: u32 = 256 * 1024; // 256KB (was 16MB, reduced for embedded)
@@ -183,6 +184,16 @@ pub fn new_ping_event() -> Event {
             stream_id: 0,
         },
         body: Bytes::new(),
+    }
+}
+
+pub fn new_window_update_event(sid: u32, increment: u32) -> Event {
+    Event {
+        header: Header {
+            flag_len: get_flag_len(4, FLAG_WIN_UPDATE),
+            stream_id: sid,
+        },
+        body: Bytes::copy_from_slice(&increment.to_le_bytes()),
     }
 }
 
@@ -386,5 +397,25 @@ mod tests {
             writer.written,
             expected_bytes(get_flag_len(body.len() as u32, FLAG_DATA), 42, &body)
         );
+    }
+
+    #[tokio::test]
+    async fn write_read_window_update_event() {
+        let ev = new_window_update_event(42, 131072);
+        assert_eq!(ev.header.flags(), FLAG_WIN_UPDATE);
+        assert_eq!(ev.header.len(), 4);
+        assert_eq!(ev.header.stream_id, 42);
+        let increment = u32::from_le_bytes(ev.body[..4].try_into().unwrap());
+        assert_eq!(increment, 131072);
+
+        let mut writer = PartialVecWriter::new(1024);
+        write_event(&mut writer, ev).await.unwrap();
+
+        let mut reader = &writer.written[..];
+        let decoded = read_event(&mut reader).await.unwrap();
+        assert_eq!(decoded.header.flags(), FLAG_WIN_UPDATE);
+        assert_eq!(decoded.header.stream_id, 42);
+        let decoded_increment = u32::from_le_bytes(decoded.body[..4].try_into().unwrap());
+        assert_eq!(decoded_increment, 131072);
     }
 }

--- a/src/mux/mod.rs
+++ b/src/mux/mod.rs
@@ -4,5 +4,5 @@ mod stream;
 
 pub use connection::Connection;
 pub use connection::Mode;
-pub use connection::DEFAULT_STREAM_CHANNEL_SIZE;
+pub use connection::INITIAL_STREAM_WINDOW;
 pub use stream::MuxStream;

--- a/src/mux/stream.rs
+++ b/src/mux/stream.rs
@@ -2,9 +2,12 @@ use crate::utils;
 use anyhow::Result;
 use bytes::Bytes;
 use futures::ready;
+use futures::task::AtomicWaker;
 use futures::SinkExt;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
 use tokio::io::ReadBuf;
@@ -12,33 +15,116 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio_util::sync::PollSender;
 
+/// Per-stream flow control state shared between dispatcher and MuxStream.
+/// The dispatcher credits send_window (on inbound WINDOW_UPDATE) and sets closed.
+/// MuxStream deducts send_window (on poll_write) and registers write_waker.
+pub struct StreamFlow {
+    send_window: AtomicU32,
+    closed: AtomicBool,
+    write_waker: AtomicWaker,
+}
+
+impl StreamFlow {
+    pub fn new(initial_window: u32) -> Self {
+        Self {
+            send_window: AtomicU32::new(initial_window),
+            closed: AtomicBool::new(false),
+            write_waker: AtomicWaker::new(),
+        }
+    }
+
+    pub fn available(&self) -> u32 {
+        if self.closed.load(Ordering::Acquire) {
+            return 0;
+        }
+        self.send_window.load(Ordering::Acquire)
+    }
+
+    pub fn credit(&self, increment: u32) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        self.send_window.fetch_add(increment, Ordering::Release);
+        self.write_waker.wake();
+    }
+
+    pub fn try_consume(&self, desired: usize) -> usize {
+        if self.closed.load(Ordering::Acquire) {
+            return 0;
+        }
+        loop {
+            let current = self.send_window.load(Ordering::Acquire);
+            if current == 0 {
+                return 0;
+            }
+            let n = desired.min(current as usize);
+            match self.send_window.compare_exchange(
+                current,
+                current - n as u32,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return n,
+                Err(_) => continue,
+            }
+        }
+    }
+
+    pub fn register_waker(&self, waker: &Waker) {
+        self.write_waker.register(waker);
+    }
+
+    pub fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Acquire)
+    }
+
+    pub fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.write_waker.wake();
+    }
+}
+
+pub type StreamDataReceiver = mpsc::UnboundedReceiver<Option<Bytes>>;
+
+pub struct NewStreamParams {
+    pub stream_id: u32,
+    pub sender: mpsc::UnboundedSender<Option<Bytes>>,
+    pub receiver: Option<StreamDataReceiver>,
+    pub flow: Arc<StreamFlow>,
+}
+
+pub enum Control {
+    AcceptStream(oneshot::Sender<Result<MuxStream>>),
+    NewStream(NewStreamParams),
+    StreamData(u32, Bytes, bool),
+    StreamShutdown(u32, bool),
+    StreamClose(u32, bool),
+    WindowUpdateFromPeer(u32, u32),
+    WindowUpdateToPeer(u32, u32),
+    Ping,
+    Close,
+}
+
 pub struct MuxStream {
     id: u32,
     ev_writer: PollSender<Control>,
-    inbound_reader: mpsc::Receiver<Option<Bytes>>,
+    inbound_reader: mpsc::UnboundedReceiver<Option<Bytes>>,
     recv_buf: Bytes,
     initial_close: bool,
     close_by_remote: bool,
     read_eof: bool,
-}
-
-type StreamDataReceiver = mpsc::Receiver<Option<Bytes>>;
-
-pub enum Control {
-    AcceptStream(oneshot::Sender<Result<MuxStream>>),
-    NewStream((u32, mpsc::Sender<Option<Bytes>>, Option<StreamDataReceiver>)),
-    StreamData(u32, Bytes, bool),
-    StreamShutdown(u32, bool),
-    StreamClose(u32, bool),
-    Ping,
-    Close,
+    flow: Arc<StreamFlow>,
+    consumed_since_update: u32,
+    window_update_threshold: u32,
 }
 
 impl MuxStream {
     pub fn new(
         id: u32,
         ev_writer: mpsc::Sender<Control>,
-        inbound_reader: mpsc::Receiver<Option<Bytes>>,
+        inbound_reader: mpsc::UnboundedReceiver<Option<Bytes>>,
+        flow: Arc<StreamFlow>,
+        initial_stream_window: u32,
     ) -> Self {
         Self {
             id,
@@ -48,6 +134,9 @@ impl MuxStream {
             initial_close: false,
             close_by_remote: false,
             read_eof: false,
+            flow,
+            consumed_since_update: 0,
+            window_update_threshold: initial_stream_window / 2,
         }
     }
 
@@ -57,6 +146,25 @@ impl MuxStream {
 
     fn close_reader(&mut self) {
         self.inbound_reader.close();
+    }
+
+    fn maybe_send_window_update(&mut self, bytes_read: u32) {
+        self.consumed_since_update += bytes_read;
+        if self.consumed_since_update >= self.window_update_threshold {
+            if let Some(sender) = self.ev_writer.get_ref() {
+                match sender.try_send(Control::WindowUpdateToPeer(
+                    self.id,
+                    self.consumed_since_update,
+                )) {
+                    Ok(()) => {
+                        self.consumed_since_update = 0;
+                    }
+                    Err(_) => {
+                        // Keep consumed_since_update — retry on next poll_read
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -74,8 +182,9 @@ impl AsyncRead for MuxStream {
             } else {
                 self.recv_buf.slice(copy_n..)
             };
+            self.maybe_send_window_update(copy_n as u32);
             return Poll::Ready(Ok(()));
-        };
+        }
         if self.read_eof {
             self.close_reader();
             return Poll::Ready(Ok(()));
@@ -84,8 +193,8 @@ impl AsyncRead for MuxStream {
         match self.inbound_reader.poll_recv(cx) {
             Poll::Ready(Some(data)) => match data {
                 Some(b) => {
-                    let mut copy_n: usize = b.len();
-                    if 0 == copy_n {
+                    let mut copy_n = b.len();
+                    if copy_n == 0 {
                         self.read_eof = true;
                         self.close_reader();
                         return Poll::Ready(Ok(()));
@@ -93,10 +202,11 @@ impl AsyncRead for MuxStream {
                     if copy_n > buf.remaining() {
                         copy_n = buf.remaining();
                     }
-                    buf.put_slice(&b[0..copy_n]);
+                    buf.put_slice(&b[..copy_n]);
                     if copy_n < b.len() {
                         self.recv_buf = b.slice(copy_n..);
                     }
+                    self.maybe_send_window_update(copy_n as u32);
                     Poll::Ready(Ok(()))
                 }
                 None => {
@@ -109,7 +219,6 @@ impl AsyncRead for MuxStream {
                 }
             },
             Poll::Ready(None) => {
-                // Poll::Ready(Ok(()))
                 self.close_reader();
                 Poll::Ready(Err(std::io::Error::new(
                     std::io::ErrorKind::ConnectionReset,
@@ -140,26 +249,65 @@ impl AsyncWrite for MuxStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, std::io::Error>> {
-        if self.close_by_remote {
+        if self.close_by_remote || self.flow.is_closed() {
             return Poll::Ready(Err(std::io::Error::new(
-                std::io::ErrorKind::ConnectionReset,
-                "close by remote",
+                std::io::ErrorKind::BrokenPipe,
+                "stream closed",
             )));
         }
         if buf.is_empty() {
             return Poll::Ready(Ok(0));
         }
-        match ready!(self.ev_writer.poll_reserve(cx)) {
-            Err(e) => Poll::Ready(Err(utils::make_io_error(&e.to_string()))),
-            Ok(_v) => {
-                let ctrl = Control::StreamData(self.id, Bytes::copy_from_slice(buf), false);
-                match self.ev_writer.send_item(ctrl) {
-                    Ok(()) => Poll::Ready(Ok(buf.len())),
-                    Err(ex) => Poll::Ready(Err(utils::make_io_error(&ex.to_string()))),
-                }
+
+        if self.flow.available() == 0 {
+            self.flow.register_waker(cx.waker());
+            if self.flow.is_closed() {
+                return Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "stream closed",
+                )));
+            }
+            if self.flow.available() == 0 {
+                return Poll::Pending;
             }
         }
+
+        match self.ev_writer.poll_reserve(cx) {
+            Poll::Pending => {
+                self.flow.register_waker(cx.waker());
+                if self.flow.is_closed() {
+                    return Poll::Ready(Err(std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        "stream closed",
+                    )));
+                }
+                return Poll::Pending;
+            }
+            Poll::Ready(Err(e)) => {
+                return Poll::Ready(Err(utils::make_io_error(&e.to_string())));
+            }
+            Poll::Ready(Ok(_)) => {}
+        }
+
+        let allowed = self.flow.try_consume(buf.len());
+        if allowed == 0 {
+            return Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "stream closed",
+            )));
+        }
+
+        let data = Bytes::copy_from_slice(&buf[..allowed]);
+        let stream_id = self.id;
+        match self
+            .ev_writer
+            .send_item(Control::StreamData(stream_id, data, false))
+        {
+            Ok(()) => Poll::Ready(Ok(allowed)),
+            Err(ex) => Poll::Ready(Err(utils::make_io_error(&ex.to_string()))),
+        }
     }
+
     fn poll_flush(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -169,12 +317,12 @@ impl AsyncWrite for MuxStream {
             Ok(_v) => Poll::Ready(Ok(())),
         }
     }
+
     fn poll_shutdown(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
         if self.read_eof {
-            // do nothing
             Poll::Ready(Ok(()))
         } else if !self.initial_close {
             self.initial_close = true;
@@ -197,11 +345,116 @@ impl Drop for MuxStream {
         if let Some(sender) = self.ev_writer.get_ref() {
             if !self.close_by_remote {
                 let stream_close = Control::StreamClose(self.id, false);
-                // 使用 try_send 避免在 Drop 中 spawn 异步任务
                 if let Err(e) = sender.try_send(stream_close) {
                     tracing::debug!("stream {} drop send close failed: {}", self.id, e);
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::task::{Wake, Waker};
+
+    struct TestWaker {
+        woken: std::sync::atomic::AtomicBool,
+    }
+    impl TestWaker {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                woken: std::sync::atomic::AtomicBool::new(false),
+            })
+        }
+        fn was_woken(&self) -> bool {
+            self.woken.load(std::sync::atomic::Ordering::Acquire)
+        }
+    }
+    impl Wake for TestWaker {
+        fn wake(self: Arc<Self>) {
+            self.woken.store(true, std::sync::atomic::Ordering::Release);
+        }
+    }
+
+    #[test]
+    fn stream_flow_initial_available() {
+        let flow = StreamFlow::new(256 * 1024);
+        assert_eq!(flow.available(), 256 * 1024);
+        assert!(!flow.is_closed());
+    }
+
+    #[test]
+    fn stream_flow_try_consume_basic() {
+        let flow = StreamFlow::new(1000);
+        let consumed = flow.try_consume(600);
+        assert_eq!(consumed, 600);
+        assert_eq!(flow.available(), 400);
+
+        let consumed2 = flow.try_consume(500);
+        assert_eq!(consumed2, 400);
+        assert_eq!(flow.available(), 0);
+    }
+
+    #[test]
+    fn stream_flow_try_consume_returns_zero_when_empty() {
+        let flow = StreamFlow::new(100);
+        let _ = flow.try_consume(100);
+        assert_eq!(flow.try_consume(1), 0);
+    }
+
+    #[test]
+    fn stream_flow_credit_adds_window() {
+        let flow = StreamFlow::new(100);
+        let _ = flow.try_consume(100);
+        assert_eq!(flow.available(), 0);
+        flow.credit(50);
+        assert_eq!(flow.available(), 50);
+    }
+
+    #[test]
+    fn stream_flow_credit_wakes_writer() {
+        let flow = StreamFlow::new(0);
+        let test_waker = TestWaker::new();
+        let waker = Waker::from(test_waker.clone());
+        flow.register_waker(&waker);
+        assert!(!test_waker.was_woken());
+
+        flow.credit(100);
+        assert!(test_waker.was_woken());
+    }
+
+    #[test]
+    fn stream_flow_close_returns_zero_available() {
+        let flow = StreamFlow::new(1000);
+        flow.close();
+        assert_eq!(flow.available(), 0);
+        assert!(flow.is_closed());
+    }
+
+    #[test]
+    fn stream_flow_close_wakes_writer() {
+        let flow = StreamFlow::new(0);
+        let test_waker = TestWaker::new();
+        let waker = Waker::from(test_waker.clone());
+        flow.register_waker(&waker);
+
+        flow.close();
+        assert!(test_waker.was_woken());
+    }
+
+    #[test]
+    fn stream_flow_try_consume_returns_zero_when_closed() {
+        let flow = StreamFlow::new(1000);
+        flow.close();
+        assert_eq!(flow.try_consume(100), 0);
+    }
+
+    #[test]
+    fn stream_flow_credit_noop_when_closed() {
+        let flow = StreamFlow::new(0);
+        flow.close();
+        flow.credit(100);
+        assert_eq!(flow.available(), 0);
     }
 }

--- a/src/tunnel/client.rs
+++ b/src/tunnel/client.rs
@@ -201,7 +201,7 @@ pub(crate) async fn mux_client_loop<T: MuxClientTrait>(
                                 &mut send,
                             );
                             if let Err(e) = stream.transfer(idle_timeout_secs).await {
-                                tracing::error!("transfer finish:{}", e);
+                                tracing::debug!("transfer finish:{}", e);
                             }
                         } else if let Some(udp_stream) = event.udp_stream {
                             let (mut local_reader, mut local_writer) = tokio::io::split(udp_stream);
@@ -232,7 +232,7 @@ pub(crate) async fn mux_client_loop<T: MuxClientTrait>(
                                 &mut send,
                             );
                             if let Err(e) = stream.transfer(idle_timeout_secs).await {
-                                tracing::error!("transfer finish:{}", e);
+                                tracing::debug!("transfer finish:{}", e);
                             }
                         }
                         decrement_gauge!("client_proxy_streams", 1.0);

--- a/src/tunnel/client.rs
+++ b/src/tunnel/client.rs
@@ -168,7 +168,7 @@ pub(crate) async fn mux_client_loop<T: MuxClientTrait>(
     while let Some(msg) = receiver.recv().await {
         match msg {
             Message::OpenStream(event) => {
-                tracing::info!("Proxy request to {}", event.event.addr);
+                // tracing::info!("Proxy request to {}", event.event.addr);
                 if let Ok((mut send, mut recv)) = client.open_stream().await {
                     increment_gauge!("client_proxy_streams", 1.0);
                     tokio::spawn(async move {
@@ -244,16 +244,14 @@ pub(crate) async fn mux_client_loop<T: MuxClientTrait>(
             Message::HealthCheck => {
                 let _ = client.health_check().await;
             }
-            Message::AddConnection(c) => {
-                match c.downcast::<T::Connection>().ok() {
-                    Some(obj) => {
-                        let _ = client.add_connection(*obj);
-                    }
-                    None => {
-                        tracing::error!("AddConnection failed: connection type mismatch");
-                    }
+            Message::AddConnection(c) => match c.downcast::<T::Connection>().ok() {
+                Some(obj) => {
+                    let _ = client.add_connection(*obj);
                 }
-            }
+                None => {
+                    tracing::error!("AddConnection failed: connection type mismatch");
+                }
+            },
         }
     }
 }

--- a/src/tunnel/local.rs
+++ b/src/tunnel/local.rs
@@ -1,10 +1,10 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use crate::tunnel::client::ProxySender;
 use crate::tunnel::http_local::{handle_http, handle_https};
 use crate::tunnel::socks5_local::handle_socks5;
 use crate::tunnel::tls_local::{handle_tls, valid_tls_version};
-use crate::tunnel::client::ProxySender;
 use crate::utils::new_tcp_listener;
 use anyhow::{anyhow, Result};
 use tokio::net::TcpStream;
@@ -21,7 +21,7 @@ async fn handle_local_tunnel(
     match peek_buf[0] {
         5 => {
             //socks5
-            tracing::info!("[{}]Accept client as SOCKS5 proxy.", tunnel_id);
+            // tracing::info!("[{}]Accept client as SOCKS5 proxy.", tunnel_id);
             handle_socks5(tunnel_id, inbound, sender).await?;
             return Ok(());
         }
@@ -35,7 +35,7 @@ async fn handle_local_tunnel(
         }
     }
     if valid_tls_version(&peek_buf[..]) {
-        tracing::info!("[{}]Accept client as TLS proxy.", tunnel_id);
+        // tracing::info!("[{}]Accept client as TLS proxy.", tunnel_id);
         handle_tls(tunnel_id, inbound, sender).await?;
         return Ok(());
     }
@@ -43,11 +43,11 @@ async fn handle_local_tunnel(
         let prefix_str = prefix_str.to_uppercase();
         match prefix_str.as_str() {
             "GET" | "PUT" | "POS" | "DEL" | "OPT" | "TRA" | "PAT" | "HEA" | "CON" | "UPG" => {
-                tracing::info!(
-                    "[{}]Accept client as HTTP proxy with method:{}",
-                    tunnel_id,
-                    prefix_str
-                );
+                // tracing::info!(
+                //     "[{}]Accept client as HTTP proxy with method:{}",
+                //     tunnel_id,
+                //     prefix_str
+                // );
                 //http proxy
                 if prefix_str.as_str() == "CON" {
                     handle_https(tunnel_id, inbound, sender).await?;
@@ -85,13 +85,20 @@ pub async fn start_local_tunnel_server(
         }
     }
 
-    tracing::info!("Start local TCP listen at {} (max connections: {})", addr, max_connections);
+    tracing::info!(
+        "Start local TCP listen at {} (max connections: {})",
+        addr,
+        max_connections
+    );
     let mut tunnel_id_seed: u32 = 0;
     while let Ok((inbound, _)) = listener.accept().await {
         let permit = match semaphore.clone().try_acquire_owned() {
             Ok(p) => p,
             Err(_) => {
-                tracing::warn!("Max connections ({}) reached, rejecting new connection", max_connections);
+                tracing::warn!(
+                    "Max connections ({}) reached, rejecting new connection",
+                    max_connections
+                );
                 continue;
             }
         };

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -4,9 +4,9 @@ mod local;
 #[cfg(target_os = "linux")]
 mod udp_local;
 
-mod socks5_local;
 mod s2n_quic_client;
 mod s2n_quic_remote;
+mod socks5_local;
 mod stream;
 mod tls_client;
 mod tls_local;
@@ -39,7 +39,7 @@ pub async fn start_tunnel_client(
     cert_path: &std::path::Path,
     host: &str,
     idle_timeout_secs: usize,
-    stream_channel_size: usize,
+    stream_window: u32,
     app_config: std::sync::Arc<crate::app_config::AppConfig>,
 ) -> anyhow::Result<()> {
     match url.scheme() {
@@ -49,20 +49,13 @@ pub async fn start_tunnel_client(
                 cert_path,
                 host,
                 idle_timeout_secs,
-                stream_channel_size,
+                stream_window,
                 app_config,
             )
             .await
         }
         "quic" => {
-            start_tunnel_client_quic(
-                url,
-                cert_path,
-                host,
-                app_config,
-                idle_timeout_secs,
-            )
-            .await
+            start_tunnel_client_quic(url, cert_path, host, app_config, idle_timeout_secs).await
         }
         _ => Err(anyhow::anyhow!("unsupported scheme: {}", url.scheme())),
     }

--- a/src/tunnel/stream.rs
+++ b/src/tunnel/stream.rs
@@ -63,12 +63,14 @@ async fn timeout_copy_impl<R: AsyncReadExt + Unpin, W: AsyncWriteExt + Unpin>(
     state.touch();
     loop {
         if state.abort.load(Relaxed) {
+            metrics::counter!("mux.stream.close.abort", 1);
             return Err(anyhow!("abort"));
         }
         match timeout(check_timeout_secs, r.read(&mut buf)).await {
             Err(_) => {
                 let (idle_millis, last_active_millis) = state.idle_snapshot();
                 if idle_millis >= timeout_sec.saturating_mul(1000) {
+                    metrics::counter!("mux.stream.close.idle_timeout", 1);
                     return Err(anyhow!(format!(
                         "timeout after inactive {}ms, last active at +{}ms",
                         idle_millis, last_active_millis
@@ -80,15 +82,18 @@ async fn timeout_copy_impl<R: AsyncReadExt + Unpin, W: AsyncWriteExt + Unpin>(
             Ok(Ok(n)) => {
                 state.touch();
                 if n == 0 {
+                    metrics::counter!("mux.stream.close.eof", 1);
                     break;
                 };
                 if let Err(ex) = w.write_all(&buf[0..n]).await {
                     state.abort.store(true, Relaxed);
+                    metrics::counter!("mux.stream.close.write_error", 1);
                     return Err(ex.into());
                 }
             }
             Ok(Err(e)) => {
                 state.abort.store(true, Relaxed);
+                metrics::counter!("mux.stream.close.read_error", 1);
                 return Err(e.into());
             }
         }

--- a/src/tunnel/tls_client.rs
+++ b/src/tunnel/tls_client.rs
@@ -24,15 +24,15 @@ use crate::utils::read_tokio_tls_certs;
 pub struct TlsConnection {
     pub(crate) inner: Option<mux::Connection>,
     pub(crate) id: u32,
-    pub(crate) stream_channel_size: usize,
+    pub(crate) stream_window: u32,
 }
 
 impl TlsConnection {
-    pub fn new(stream_channel_size: usize) -> Self {
+    pub fn new(stream_window: u32) -> Self {
         Self {
             inner: None,
             id: 0,
-            stream_channel_size,
+            stream_window,
         }
     }
 }
@@ -54,12 +54,12 @@ impl MuxConnection for TlsConnection {
         match new_tls_connection(url, key_path, host).await {
             Ok(c) => {
                 let (r, w) = tokio::io::split(c);
-                let mux_conn = mux::Connection::new_with_stream_channel_size(
+                let mux_conn = mux::Connection::new_with_stream_window(
                     r,
                     w,
                     mux::Mode::Client,
                     self.id,
-                    self.stream_channel_size,
+                    self.stream_window,
                 );
                 self.inner = Some(mux_conn);
                 Ok(())
@@ -112,7 +112,7 @@ impl MuxClient<TlsConnection> {
         host: &String,
         count: usize,
         idle_timeout_secs: usize,
-        stream_channel_size: usize,
+        stream_window: u32,
     ) -> anyhow::Result<ProxySender> {
         match url.scheme() {
             "tls" => {
@@ -128,7 +128,7 @@ impl MuxClient<TlsConnection> {
                     let mut tls_conn: TlsConnection = TlsConnection {
                         inner: None,
                         id: i as u32,
-                        stream_channel_size,
+                        stream_window,
                     };
                     match tls_conn.connect(url, cert_path, host).await {
                         Err(e) => {
@@ -217,7 +217,7 @@ pub async fn new_tls_client(
     host: &String,
     count: usize,
     idle_timeout_secs: usize,
-    stream_channel_size: usize,
+    stream_window: u32,
 ) -> anyhow::Result<ProxySender> {
     MuxClient::<TlsConnection>::from(
         url,
@@ -225,7 +225,7 @@ pub async fn new_tls_client(
         host,
         count,
         idle_timeout_secs,
-        stream_channel_size,
+        stream_window,
     )
     .await
 }

--- a/src/tunnel/tls_remote.rs
+++ b/src/tunnel/tls_remote.rs
@@ -20,7 +20,7 @@ pub async fn start_tls_remote_server(
     cert_path: &Path,
     key_path: &Path,
     idle_timeout_secs: usize,
-    stream_channel_size: usize,
+    stream_window: u32,
     registry: Option<crate::tunnel::tunnel_registry::SharedRegistry>,
 ) -> Result<()> {
     let certs = read_tokio_tls_certs(cert_path)?;
@@ -52,14 +52,8 @@ pub async fn start_tls_remote_server(
         let fut = async move {
             let stream = acceptor.accept(stream).await?;
             tracing::info!("TLS connection incoming");
-            handle_tls_connection(
-                stream,
-                conn_id,
-                idle_timeout_secs,
-                stream_channel_size,
-                registry,
-            )
-            .await?;
+            handle_tls_connection(stream, conn_id, idle_timeout_secs, stream_window, registry)
+                .await?;
             Ok(()) as Result<()>
         };
 
@@ -76,16 +70,16 @@ pub(crate) async fn handle_tls_connection<T: AsyncRead + AsyncWrite + Unpin + Se
     conn: T,
     id: u32,
     idle_timeout_secs: usize,
-    stream_channel_size: usize,
+    stream_window: u32,
     registry: Option<crate::tunnel::tunnel_registry::SharedRegistry>,
 ) -> Result<()> {
     let (r, w) = tokio::io::split(conn);
-    let mux_conn = Arc::new(mux::Connection::new_with_stream_channel_size(
+    let mux_conn = Arc::new(mux::Connection::new_with_stream_window(
         r,
         w,
         mux::Mode::Server,
         id,
-        stream_channel_size,
+        stream_window,
     ));
 
     let auth_stream = mux_conn.accept_stream().await?;

--- a/src/tunnel/tunnel_client.rs
+++ b/src/tunnel/tunnel_client.rs
@@ -19,7 +19,7 @@ pub async fn start_tunnel_client_tls(
     cert_path: &Path,
     host: &str,
     idle_timeout_secs: usize,
-    stream_channel_size: usize,
+    stream_window: u32,
     app_config: Arc<AppConfig>,
 ) -> Result<()> {
     const INITIAL_BACKOFF_SECS: u64 = 1;
@@ -40,7 +40,7 @@ pub async fn start_tunnel_client_tls(
                 url,
                 cert_path,
                 host,
-                stream_channel_size,
+                stream_window,
                 &client_id,
                 &entries,
                 idle_timeout_secs,
@@ -75,12 +75,12 @@ async fn run_tunnel_connection_tls(
     url: &Url,
     cert_path: &Path,
     host: &str,
-    stream_channel_size: usize,
+    stream_window: u32,
     client_id: &str,
     entries: &[TunnelEntry],
     idle_timeout_secs: usize,
 ) -> Result<()> {
-    let mut conn = TlsConnection::new(stream_channel_size);
+    let mut conn = TlsConnection::new(stream_window);
     conn.connect(url, cert_path, host).await?;
     tracing::info!("TLS tunnel connection established");
 
@@ -125,7 +125,10 @@ async fn run_tunnel_connection_tls(
     }
 }
 
-pub async fn handle_reverse_stream<R: tokio::io::AsyncRead + Unpin, W: tokio::io::AsyncWrite + Unpin>(
+pub async fn handle_reverse_stream<
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+>(
     recv: &mut R,
     send: &mut W,
     idle_timeout_secs: usize,

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -32,7 +32,8 @@ pub fn format_metrics(registry: &MetricsRegistry) -> String {
     metrics_info.push_str("Gauges:\n");
     registry.visit_gauges(|name, gauge| {
         let n = gauge.load(std::sync::atomic::Ordering::Relaxed);
-        metrics_info.push_str(format!("  {}:{}\n", name, f64::from_bits(n) as u64).as_str());
+        let value = f64::from_bits(n);
+        metrics_info.push_str(format!("  {}:{:.2}\n", name, value).as_str());
     });
     metrics_info.push_str("Counters:\n");
     registry.visit_counters(|name, counter| {
@@ -44,6 +45,25 @@ pub fn format_metrics(registry: &MetricsRegistry) -> String {
             )
             .as_str(),
         );
+    });
+    metrics_info.push_str("Histograms:\n");
+    registry.visit_histograms(|name, histogram| {
+        let samples: Vec<f64> = histogram.data();
+        if samples.is_empty() {
+            metrics_info.push_str(format!("  {}: no data\n", name).as_str());
+        } else {
+            let count = samples.len();
+            let sum: f64 = samples.iter().sum();
+            let min = samples.iter().cloned().fold(f64::INFINITY, f64::min);
+            let max = samples.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            metrics_info.push_str(
+                format!(
+                    "  {}: count={} sum={:.2} min={:.2} max={:.2}\n",
+                    name, count, sum, min, max
+                )
+                .as_str(),
+            );
+        }
     });
     metrics_info
 }


### PR DESCRIPTION
## Summary

- Add TLS mux flow control with `FLAG_WIN_UPDATE`: per-stream unbounded channels eliminate dispatcher head-of-line blocking, while `StreamFlow` and `recv_window` enforce end-to-end backpressure.
- Rename `--mux-stream-channel-size` to `--mux-stream-window` (default 256KB); raise default idle timeout to 120s for longer-lived proxy/tunnel connections.
- Add mux observability: aggregate recv/send window gauges, stream close reason counters, histogram output in `/metrics`; split README into English (`README.md`) and Chinese (`README.zh-CN.md`).

## Test plan

- [x] `cargo test` — 27 tests pass
- [x] TLS proxy smoke test: SOCKS5/HTTP through client → server → target
- [x] Concurrent downloads over single TLS mux connection (verify no HOL blocking / idle timeout regressions)
- [x] Reverse tunnel: `--tunnel` client + `--tunnel-port-range` server
- [x] Verify `/metrics` exposes new mux gauges and stream close counters
- [x] Deploy client and server together (WINDOW_UPDATE requires both sides on this branch)